### PR TITLE
Add !== for js and php's not triple-equal

### DIFF
--- a/key-combo.el
+++ b/key-combo.el
@@ -331,7 +331,7 @@ which in most cases is shared with all other buffers in the same major mode.
     ("%"  . " % ")
     ("^"  . " ^ ");; c XOR
     ("!" . key-combo-execute-orignal) ;;not " !" because of ruby symbol
-    ("!=" . " != ")
+    ("!=" . (" != " " !== ")) ;;" !== " for js and php
     ;; (":" . " :");;only for ruby
     ;; ("&"  . (" & " " && ")) ;;not use because c pointer
     ;; ("*"  . " * " ) ;;not use because c pointer


### PR DESCRIPTION
`===` is registered as global default combo, so `!==` should be registered too.
