### PR TITLE
Clean key-combo-comment-or-stringp (Fix #20)

### DIFF
--- a/key-combo.el
+++ b/key-combo.el
@@ -157,7 +157,9 @@ The binding is probably a symbol with a function definition."
   (nth 4 (parse-partial-sexp (point) (point-min))))
 
 (defun key-combo-comment-or-stringp ()
-  (or (key-combo-in-stringp) (key-combo-in-commentp)))
+  (if (or (key-combo-in-stringp) (key-combo-in-commentp))
+      t
+    nil))
 
 ;;(browse-url "http://q.hatena.ne.jp/1226571494")
 (defun key-combo-count-boundary (last-undo-list)


### PR DESCRIPTION
It is not buggy to use text-property for judging cursor is in comment or text.
parse-partial-sexp is built-in, and works for other than elisp modes.

I refered to context-skk.el(http://openlab.ring.gr.jp/skk/skk/main/context-skk.el)
