### PR TITLE
See the previous character and delete only it when it is space

### DIFF
--- a/key-combo.el
+++ b/key-combo.el
@@ -176,11 +176,10 @@ The binding is probably a symbol with a function definition."
       ))
    (t
     (let ((p (point)))
+      (if (and (eq ?  (char-before))
+               (eq ?  (aref string 0)))
+          (delete-backward-char 1))
       (insert string)
-      (if (eq ?  (aref string 0))
-          (save-excursion
-            (goto-char p)
-            (just-one-space)))
       (when (string-match "\n" string)
         (indent-according-to-mode)
         (indent-region p (point)))))))


### PR DESCRIPTION
When I hit a = after space indentation, all the spaces went away.
This is especially irritating with Haskell, which uses many indentational spaces between operators.

This patch checks only the previous character, and remove just one space when it should.
