### PR TITLE
[Fix #40] Add `key-combo` to `eldoc-message-commands`

### DIFF
--- a/key-combo.el
+++ b/key-combo.el
@@ -635,6 +635,9 @@ which in most cases is shared with all other buffers in the same major mode.
              ))
           )))
 
+(eval-after-load "eldoc"
+  '(eldoc-add-command "key-combo"))
+
 ;; (listify-key-sequence
 ;;  (kbd "M-C-d M-C-d"))
 ;; (listify-key-sequence


### PR DESCRIPTION
Ok. I figured it out. You have to explicitly declare `key-combo` in eldoc. 