### PR TITLE
Cleanup and readme rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,91 @@
-key-combo.el
-========
-
 [![Build Status](https://secure.travis-ci.org/uk-ar/key-combo.png)](http://travis-ci.org/uk-ar/key-combo)
 
-;;
-;; (require 'key-combo)
-;; (key-combo-mode 1)
-;;
-;; and some chords, for example
-;;
-;; (key-combo-define-global (kbd "=") '(" = " " == " " === " ))
+# key-combo.el
 
-;; (key-combo-define-global (kbd "=>") " => ")
-;;
-;; or load default settings
-;;
-;; (key-combo-load-default)
+*key-combo* is an Emacs package that provides "cycling" key-binding. Multiple
+commands are executed sequentially with a repeated keypress of a single
+key. Besides single key, a whole cords of keys could be bound to a command in
+order to create complex "smart operators".
 
-;; Integrating multiple commands into one command is sometimes
-;; useful. Pressing C-e at the end of line is useless and adding the
-;; other behavior in this situation is safe.
-;; 
-;; For example, defining `my-end': if point is at the end of line, go
-;; to the end of buffer, otherwise go to the end of line. Just evaluate it!
-;;
-;; (define-sequential-command my-end  end-of-line end-of-buffer)
-;; (global-set-key "\C-e" 'my-end)
-;;
-;; Consequently, pressing C-e C-e is `end-of-buffer'!
-;;
-;; `define-sequential-command' is a macro that defines a command whose
-;; behavior is changed by sequence of calls of the same command.
-;;
-;; `seq-return' is a command to return to the position when sequence
-;; of calls of the same command was started.
 
-*key-combo* is a Emacs plugin to support input several candidates with a single 
-key, like ess-smart-underscore in Emacs Speaks Statistics -- when user types 
-"_" key, it inserts " <- " for the first time or it replaces " <- " by "_" for 
-the second time.  This plugin provides functions to support to define such 
-key bindings easily.  For example: 
+## Instalation
 
-- <kbd>=</kbd>:insert ` = `
-- <kbd>==</kbd>:insert ` == `
-- <kbd>===</kbd>:insert ` === `
-- <kbd>====</kbd>:insert ` = `
 
-- <kbd>=</kbd>:insert ` = `
-- <kbd>=></kbd>:insert ` => `
+This package is available from [MELPA](http://melpa.org/#/). Alternatively you
+can place `key-combo.el` into your emacs path and add `(require 'key-combo)` to
+your init file.
 
-- <kbd>C-a</kbd>:move-beginning-of-line
-- <kbd>C-a C-a</kbd>:beginning-of-buffer
-- <kbd>C-a C-a C-a</kbd>:return
 
-1st key|2nd key|3rd key|command
-------|------|----|---
-=   |||   ` = `
-=|=|| ` == `
-=|=|=| ` === `
-=|>|| ` => `
+## Activation
+
+
+Activate `key-combo-mode` localy in a mode hook with:
+
+```lisp
+(key-combo-mode 1)
+```
+
+or globally with
+
+```lisp
+(global-key-combo-mode t)
+```
+
+## Configuration
+
+Define cycling key combos globally with `key-combo-define-global` function:
+
+```lisp
+(key-combo-define-global "=" '(" = " " == " " === " )) ;cycling
+(key-combo-define-global "=>" " => ")
+(key-combo-define-global "C-a" `(back-to-indentation move-beginning-of-line
+                                 beginning-of-buffer key-combo-return))
+(key-combo-define-global "C-e" '(move-end-of-line end-of-buffer key-combo-return))
+```
+
+or for each modes separately:
+
+```lisp
+(key-combo-define emacs-lisp-mode-map "="  '("= " "eq " "equal "))
+```
+
+There is also `key-combo-define-local` that should be used inside mode hooks.
+
+
+To facilitate quick declaration of cord, `key-combo.el` provides
+`key-combo-define-hook` which is used to setup same hook for a list of
+modes. Here is a simple example for `emacs-lisp`:
+
+```lisp
+
+(defvar my-lisp-mode-hooks
+  '(lisp-mode-hook
+    emacs-lisp-mode-hook
+    lisp-interaction-mode-hook
+    inferior-gauche-mode-hook
+    scheme-mode-hook))
+
+(defvar my-key-combos-for-lisp
+  '(("."  . ("." " . "))
+    (","  . (key-combo-execute-original))
+    (",@" . " ,@")
+    (";=" . ";=> ")
+    ("="  . ("= " "eq " "equal "))
+    (">=" . ">= ")))
+
+(key-combo-define-hook my-lisp-mode-hooks ; hooks
+                       'my-key-combo-lisp-hook ; function name
+                       my-key-combos-for-lisp)
+
+```
+
+## Default Configuration
+
+To load a range of default configurations for `lisp`, `C`, `C++`, `js`, `org`
+etc modes, use:
+
+```lisp
+(key-combo-load-default)
+````
+
+See the code for details.

--- a/key-combo.el
+++ b/key-combo.el
@@ -214,6 +214,7 @@ The binding is probably a symbol with a function definition."
       ;;for unset key
       (null element)))
 
+;;;###autoload
 (defun key-combo-define (keymap key commands)
   "In KEYMAP, define key sequence KEY as COMMANDS.
 KEYMAP is a keymap.\n
@@ -252,6 +253,7 @@ If COMMANDS is list, treated as sequential commands."
         (key-combo-make-key-vector key)
         (key-combo-get-command commands))))))
 
+;;;###autoload 
 (defun key-combo-define-global (keys command)
   "Give KEY a global binding as COMMAND.\n
 See also `key-combo-define'\n
@@ -261,6 +263,7 @@ that you make with this function."
   ;;(interactive "sSet key chord globally (2 keys): \nCSet chord \"%s\" to command: ")
   (key-combo-define (current-global-map) keys command))
 
+;;;###autoload
 (defun key-combo-define-local (keys command)
   "Give KEY a local binding as COMMAND.\n
 See also `key-combo-define'\n

--- a/key-combo.el
+++ b/key-combo.el
@@ -1,5 +1,5 @@
 ;;; key-combo.el --- map key sequence to commands
-
+;; 
 ;;-------------------------------------------------------------------
 ;;
 ;; Copyright (C) 2011, 2012 Yuuki Arisawa
@@ -22,7 +22,7 @@
 ;; MA 02111-1307 USA
 ;;
 ;;-------------------------------------------------------------------
-
+;; 
 ;; Author: Yuuki Arisawa <yuuki.ari@gmail.com>
 ;; URL: https://github.com/uk-ar/key-combo
 ;; Created: 30 November 2011
@@ -30,11 +30,11 @@
 ;; Keywords: keyboard input
 
 ;;; Commentary:
-
+;; 
 ;; ########   Compatibility   ########################################
 ;;
 ;; Works with Emacs-23.2.1, 23.1.1
-
+;; 
 ;; ########   Quick start   ########################################
 ;;
 ;; Add to your ~/.emacs
@@ -52,7 +52,7 @@
 ;;  (key-combo-load-default)
 
 ;;; History:
-
+;; 
 ;; Revision 1.5.1 2012/06/06 21:36:28
 ;; * Bug fix which use flex-autopair by mistake.
 ;;
@@ -110,8 +110,10 @@
 ;; Revision 0.1
 ;; * Initial revision
 
-;; Code goes here
+;; Code
+
 (require 'cl)
+
 ;; for remove-if
 (defvar key-combo-debug nil)
 
@@ -150,8 +152,7 @@ The binding is probably a symbol with a function definition."
 
 (defun key-combo-execute-original ()
   (interactive)
-  (call-interactively (key-binding (this-command-keys-vector)))
-  )
+  (call-interactively (key-binding (this-command-keys-vector))))
 
 (defalias 'key-combo-execute-orignal 'key-combo-execute-original)
 
@@ -186,8 +187,7 @@ The binding is probably a symbol with a function definition."
     (destructuring-bind (pre post) (split-string string "`!!'")
       (key-combo-execute-macro pre)
       (save-excursion
-        (key-combo-execute-macro post))
-      ))
+        (key-combo-execute-macro post))))
    (t
     (let ((p (point)))
       (if (and (eq ?  (char-before))
@@ -206,15 +206,13 @@ The binding is probably a symbol with a function definition."
    ((listp command) command)
    ((not (stringp command)) nil)
    (t
-    command)
-   );;end cond
-  )
+    command)))
 
 (defun key-combo-elementp (element)
   (or (functionp element)
       (stringp element)
-      (null element));;for unset key
-  )
+      ;;for unset key
+      (null element)))
 
 (defun key-combo-define (keymap key commands)
   "In KEYMAP, define key sequence KEY as COMMANDS.
@@ -225,8 +223,7 @@ above 127 (such as ISO Latin-1) can be included if you use a vector.\n
 COMMANDS can be an interactive function, a string, nil, or list of these COMMAND.
 If COMMANDS is string, treated as a smartchr flavor keyboard macro.
 If COMMANDS is nil, the key-chord is removed.
-If COMMANDS is list, treated as sequential commands.
-"
+If COMMANDS is list, treated as sequential commands."
   ;;copy from key-chord-define
   (let ((base-key (list (car (listify-key-sequence key)))))
     (cond
@@ -250,20 +247,17 @@ If COMMANDS is list, treated as sequential commands.
                  (null first))
         (define-key keymap
             (key-combo-make-key-vector base-key)
-            'key-combo-execute-original))
-        )
+            'key-combo-execute-original)))
       (define-key keymap
         (key-combo-make-key-vector key)
-        (key-combo-get-command commands))
-      ))))
+        (key-combo-get-command commands))))))
 
 (defun key-combo-define-global (keys command)
   "Give KEY a global binding as COMMAND.\n
 See also `key-combo-define'\n
 Note that if KEY has a local binding in the current buffer,
 that local binding will continue to shadow any global binding
-that you make with this function.
-"
+that you make with this function."
   ;;(interactive "sSet key chord globally (2 keys): \nCSet chord \"%s\" to command: ")
   (key-combo-define (current-global-map) keys command))
 
@@ -271,8 +265,7 @@ that you make with this function.
   "Give KEY a local binding as COMMAND.\n
 See also `key-combo-define'\n
 The binding goes in the current buffer's local map,
-which in most cases is shared with all other buffers in the same major mode.
-"
+which in most cases is shared with all other buffers in the same major mode."
   ;;(interactive "sSet key chord globally (2 keys): \nCSet chord \"%s\" to command: ")
   (key-combo-define (current-local-map) keys command))
 
@@ -282,8 +275,7 @@ which in most cases is shared with all other buffers in the same major mode.
     ;; use beginning-of-buffer for keydescription
     ("C-a"   . (back-to-indentation move-beginning-of-line
                                     beginning-of-buffer key-combo-return))
-    ("C-e"   . (move-end-of-line end-of-buffer key-combo-return))
-    ))
+    ("C-e"   . (move-end-of-line end-of-buffer key-combo-return))))
 
 (defvar key-combo-lisp-default
   '(("."  . (key-combo-execute-original))
@@ -323,8 +315,7 @@ which in most cases is shared with all other buffers in the same major mode.
   "define-key-combo-load is deprecated"
   `(defun ,(intern (concat "key-combo-load-" name "-default")) ()
      (dolist (key ,(intern (concat "key-combo-" name "-default")))
-       (key-combo-define-local (key-combo-read-kbd-macro (car key)) (cdr key)))
-     ))
+       (key-combo-define-local (key-combo-read-kbd-macro (car key)) (cdr key)))))
 
 ;; for algol like language
 (defcustom key-combo-common-mode-hooks
@@ -334,8 +325,7 @@ which in most cases is shared with all other buffers in the same major mode.
     cperl-mode-hook
     javascript-mode-hook
     js-mode-hook
-    js2-mode-hook
-    )
+    js2-mode-hook)
   "Hooks that enable `key-combo-common-default' setting"
   :group 'key-combo)
 
@@ -399,8 +389,7 @@ which in most cases is shared with all other buffers in the same major mode.
     ("/* RET" . "/*\n`!!'\n*/");; add *? m-j
     ;; ("/* RET" . "/*\n*`!!'\n*/");; ToDo:change style by valiable
     ("{" . (key-combo-execute-original))
-    ("{ RET" . "{\n`!!'\n}")
-    )
+    ("{ RET" . "{\n`!!'\n}"))
   "Default binding which enabled by `key-combo-common-mode-hooks'"
   :group 'key-combo)
 
@@ -410,8 +399,7 @@ which in most cases is shared with all other buffers in the same major mode.
               key-combo-return));;back-to-indentation
     ("C-e" . (org-end-of-line
               end-of-buffer
-              key-combo-return))
-    )
+              key-combo-return)))
   "Default binding which enabled by `org-mode-hook'"
   :group 'key-combo)
 
@@ -426,10 +414,8 @@ which in most cases is shared with all other buffers in the same major mode.
 (defmacro key-combo-define-hook (hooks name keys)
   `(progn
      (defun ,(nth 1 name) ()
-       (key-combo-load-default-1 (current-local-map) ,keys)
-       )
-     (key-combo-load-by-hooks ,hooks ,name)
-     ))
+       (key-combo-load-default-1 (current-local-map) ,keys))
+     (key-combo-load-by-hooks ,hooks ,name)))
 
 ;;;###autoload
 (defun key-combo-load-default ()
@@ -468,8 +454,7 @@ which in most cases is shared with all other buffers in the same major mode.
 (defun key-combo-load-by-hooks (hooks func)
   (let ((hooks (if (consp hooks) hooks (list hooks))))
     (dolist (hook hooks)
-      (add-hook hook func t))
-    ))
+      (add-hook hook func t))))
 
 (defun key-combo-load-default-1 (map keys)
   (dolist (key keys)
@@ -487,8 +472,7 @@ which in most cases is shared with all other buffers in the same major mode.
       (progn
         (goto-char (car key-combo-start-position))
         ;; (set-window-start (selected-window) (cdr key-combo-start-position))
-        )))
-  )
+        ))))
 
 ;;(browse-url "http://q.hatena.ne.jp/1226571494")
 (defun key-combo-count-boundary (last-undo-list)
@@ -498,8 +482,7 @@ which in most cases is shared with all other buffers in the same major mode.
   "returns buffer undo list"
   ;; (message "count:%d" (1+ (key-combo-count-boundary buffer-undo-list)))
   (primitive-undo (1+ (key-combo-count-boundary buffer-undo-list))
-                  buffer-undo-list)
-  )
+                  buffer-undo-list))
 
 (defun key-combo-command-execute (command)
   "returns buffer undo list"
@@ -510,10 +493,8 @@ which in most cases is shared with all other buffers in the same major mode.
     (call-interactively command))
    ((functionp command)
     (funcall command))
-   (t (error "%s is not command" command))
-   )
-  (undo-boundary)
-  )
+   (t (error "%s is not command" command)))
+  (undo-boundary))
 
 (defvar key-combo-command-keys nil)
 (defvar key-combo-need-undop t)
@@ -524,11 +505,9 @@ which in most cases is shared with all other buffers in the same major mode.
   (let ((command (key-combo-key-binding key-combo-command-keys)))
     (if (and key-combo-need-undop
              (not (eq buffer-undo-list t)))
-        (key-combo-undo)
-      )
+        (key-combo-undo))
     (key-combo-command-execute command)
-    (setq key-combo-need-undop t)
-    ))
+    (setq key-combo-need-undop t)))
 
 (defvar key-combo-original-undo-list nil)
 
@@ -537,8 +516,7 @@ which in most cases is shared with all other buffers in the same major mode.
       (setq buffer-undo-list
             (append buffer-undo-list key-combo-original-undo-list)))
   (setq key-combo-original-undo-list nil)
-  (setq key-combo-command-keys nil)
-  )
+  (setq key-combo-command-keys nil))
 
 ;;;###autoload
 (define-minor-mode key-combo-mode
@@ -551,8 +529,7 @@ which in most cases is shared with all other buffers in the same major mode.
                 ;;post-self-insert-hook
                 #'key-combo-pre-command-function nil t)
     (remove-hook 'pre-command-hook
-                 #'key-combo-pre-command-function t))
-  )
+                 #'key-combo-pre-command-function t)))
 
 (defcustom key-combo-disable-modes nil
   "Major modes `key-combo-mode' can not run on."
@@ -632,8 +609,7 @@ which in most cases is shared with all other buffers in the same major mode.
           (t
            (if (eq last-command 'key-combo)
                (key-combo-finalize)
-             ))
-          )))
+             )))))
 
 ;; (listify-key-sequence
 ;;  (kbd "M-C-d M-C-d"))


### PR DESCRIPTION
I have removed some trailing paranthesis here and there (this is the emacs core convention). Added some missing autoloads and wrote a completely new readme. 